### PR TITLE
Improve packaging and version checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,16 +24,13 @@ jobs:
             equal: [ main, << pipeline.git.branch >> ]
           steps:
             - run:
-                name: Compress binaries
-                command: |
-                  cd dist
-                  cp audiomoth-utils-cli-linux audiomoth-utils && zip -m audiomoth-utils-cli-linux-x64.zip audiomoth-utils
-                  cp audiomoth-utils-cli-win.exe audiomoth-utils.exe && zip -m audiomoth-utils-cli-windows-x64.zip audiomoth-utils.exe
+                name: Build and compress binaries
+                command: npm run build:zip
             - persist_to_workspace:
                 root: dist
                 paths:
-                  - audiomoth-utils-cli-linux-x64.zip
-                  - audiomoth-utils-cli-windows-x64.zip
+                  - audiomoth-utils-cli-linux-x64-v*.zip
+                  - audiomoth-utils-cli-windows-x64-v*.zip
 
   release:
     docker:

--- a/README.md
+++ b/README.md
@@ -25,6 +25,30 @@ This will display the full usage information and available options.
 Currently, the CLI supports a subset of the functionality provided by the upstream AudioMoth-Utils node library.
 We aspire to gradually ramp up to provide full coverage in future releases.
 
+## Development
+
+### Building
+
+To build the CLI binaries:
+
+```bash
+$ npm run build
+```
+
+This will create platform-specific binaries in the `dist/` directory.
+
+To build and create versioned zip files for distribution:
+
+```bash
+$ npm run build:zip
+```
+
+This creates zip files like `audiomoth-utils-cli-linux-x64-v1.5.0.zip` that include the upstream library version in the filename.
+
+### Version Safety
+
+The build process includes automatic checks to ensure the installed `audiomoth-utils` version matches what's specified in `package.json`. This prevents distributing binaries with mismatched library versions.
+
 ## Versioning
 
 To check the upstream version of the AudioMoth-Utils node library wrapped by this CLI:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Neither JavaScript experience nor Node.js is required to use this tool.
 
 To see the available commands and options:
 
-
 ```bash
 $ audiomoth-utils --help
 ```
@@ -25,6 +24,15 @@ This will display the full usage information and available options.
 
 Currently, the CLI supports a subset of the functionality provided by the upstream AudioMoth-Utils node library.
 We aspire to gradually ramp up to provide full coverage in future releases.
+
+## Versioning
+
+To check the upstream version of the AudioMoth-Utils node library wrapped by this CLI:
+
+```bash
+$ audiomoth-utils --version
+```
+
 
 ## License
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -1,5 +1,6 @@
 const { Command, Option } = require("commander");
 const audiomothUtils = require("audiomoth-utils");
+const audiomothUtilsPackage = require("audiomoth-utils/package.json");
 
 /**
  * A base-10 version of parseInt where the second argument is a callback
@@ -24,6 +25,7 @@ function makeProgram() {
     .description(
       "Expand an AudioMoth T.WAV recording (a recording with amplitude thresholding or frequency triggering applied)"
     ) // TODO use addCommand to handle the subcommands
+    .version(`This is a CLI wrapper around audiomoth-utils ${audiomothUtilsPackage.version}`, "-v, --version", "display version of audiomoth-utils library")
     .arguments("<subcommand> <inputFile>")
     .option(
       "-d, --destination [outputPath]",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   },
   "scripts": {
     "start": "node ./bin/cli.js",
+    "prebuild": "node ./scripts/check-dependencies.js",
     "build": "pkg . --targets node14-linux-x64,node14-win-x64 --out-path dist",
+    "build:zip": "pnpm run build && node ./scripts/create-zip.js",
     "test": "jest"
   },
   "dependencies": {

--- a/scripts/check-dependencies.js
+++ b/scripts/check-dependencies.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+// Check that node_modules version matches package.json
+const pkg = require("../package.json");
+const installed = require("audiomoth-utils/package.json");
+
+const expectedVersion = pkg.dependencies["audiomoth-utils"];
+const installedVersion = installed.version;
+
+if (expectedVersion !== installedVersion) {
+  console.error(
+    `ERROR: node_modules audiomoth-utils version (${installedVersion}) does not match package.json (${expectedVersion})`
+  );
+  console.error('Run "npm install" to fix this issue.');
+  process.exit(1);
+}
+
+console.log(`✓ Dependencies match: audiomoth-utils@${installedVersion}`);

--- a/scripts/create-zip.js
+++ b/scripts/create-zip.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+// Create versioned zip files for distribution
+const { execSync } = require("child_process");
+const pkg = require("../package.json");
+const version = pkg.dependencies["audiomoth-utils"];
+
+console.log(`Creating versioned zip files with audiomoth-utils@${version}...`);
+
+try {
+  // Create Linux zip
+  execSync(
+    "cd dist && cp audiomoth-utils-cli-linux audiomoth-utils && zip -m audiomoth-utils-cli-linux-x64-v" +
+      version +
+      ".zip audiomoth-utils",
+    { stdio: "inherit" }
+  );
+
+  // Create Windows zip
+  execSync(
+    "cd dist && cp audiomoth-utils-cli-win.exe audiomoth-utils.exe && zip -m audiomoth-utils-cli-windows-x64-v" +
+      version +
+      ".zip audiomoth-utils.exe",
+    { stdio: "inherit" }
+  );
+
+  console.log("✓ Created versioned zip files");
+} catch (error) {
+  console.error("Failed to create zip files:", error.message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Goal

Prevent distributing binaries with mismatched upstream library versions by adding version checks and making the audiomoth-utils version visible to end users.

## What I changed and why

I add multiple failsafes to ensure version consistency.

Added `--version CLI` flag in `lib/command.js`
- Reads from the actual bundled audiomoth-utils/package.json inside the binary, not the  wrapper's package.json
- Gives users a way to verify which upstream library version they're using

Added `prebuild` dependency check: `scripts/check-dependencies.js`
- Automatically runs before npm run build
- Fails the build if node_modules audiomoth-utils version doesn't match package.json

Refactored ZIP file creation to standalone script (`scripts/` directory) and version the zip file
- New npm run build:zip command creates audiomoth-utils-cli-linux-x64-v1.7.1.zip
- Updated CI/CD to use the new `build:zip`  target
